### PR TITLE
Fix test_benchmark build

### DIFF
--- a/src/test/test_benchmark.cc
+++ b/src/test/test_benchmark.cc
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <functional>
+#include <string>
 #include <sys/time.h>
 #include <sys/resource.h>
 


### PR DESCRIPTION
It was failing on Debian 12 due to missing <string> include:

    kirr@deca:~/src/tools/go/pygolang-master/3rdparty/ratas/src/test$ g++ test_benchmark.cc
    test_benchmark.cc: In function ‘int main(int, char**)’:
    test_benchmark.cc:223:21: error: variable ‘std::string value’ has initializer but incomplete type
      223 |         std::string value = s;
          |                     ^~~~~
    test_benchmark.cc:234:21: error: variable ‘std::string value’ has initializer but incomplete type
      234 |         std::string value = s;
          |                     ^~~~~